### PR TITLE
drop the the docs config and sourceLibrary

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -3,18 +3,8 @@
     "description": "D bindings to the NetCDF library",
     "homepage": "https://github.com/John-Colvin/NetCDF-D",
     "license": "NetCDF",
-
-    "configurations": [
-        {
-            "name": "default",
-            "targetType": "sourceLibrary",
-            "libs": ["netcdf"]
-        },
-        {
-            "name": "docs",
-            "targetType": "library"
-        }
-    ],
+    
+    "libs": ["netcdf"],
     
     "buildTypes": {
         "DSddox": {


### PR DESCRIPTION
sourceLibrary is the right choice for binding, but it complicates building the docs for anyone with dub 0.9.23 because of a bug. The workaround requires the extra configuration I deleted here, which in turn would require extra code in the site building scripts, it's not worth the effort.

Once we drop dub 0.9.23 support we can switch all bindings to sourceLibrary
